### PR TITLE
Revert "[camera] Force Camera HAL1 to enable ISO speed setting and more." JB#42952

### DIFF
--- a/prjconf/macros.xml
+++ b/prjconf/macros.xml
@@ -1,4 +1,4 @@
 # device-specific macros:
 
 %device_rpm_architecture_string armv7hl
-%force_hal 1
+


### PR DESCRIPTION
This reverts commit d0d7af5cd48119716e55a1811064b73af114b0dd.

HAL1 was not stable - video recording crashed the device. Will have to fix up HAL3 instead.